### PR TITLE
Fix live site mojibake and homepage year section order

### DIFF
--- a/scripts/fix_html_encoding.py
+++ b/scripts/fix_html_encoding.py
@@ -5,12 +5,21 @@ from pathlib import Path
 
 
 def fix_mojibake(text: str) -> str:
-    if "Â" not in text and "â" not in text:
-        return text
-    try:
-        return text.encode("latin-1").decode("utf-8")
-    except (UnicodeEncodeError, UnicodeDecodeError):
-        return text
+    # Grotsky double-encodes some UTF-8 characters in HTML output. A full-file
+    # latin-1 roundtrip fails when pages contain emoji or other non-Latin-1 text,
+    # so apply targeted replacements instead.
+    replacements = (
+        ("Â·", "·"),
+        ("â€™", "'"),
+        ("â€œ", '"'),
+        ("â€\u009d", '"'),
+        ("â€”", "—"),
+        ("â€“", "–"),
+        ("â†’", "→"),
+    )
+    for old, new in replacements:
+        text = text.replace(old, new)
+    return text
 
 
 def main() -> None:

--- a/scripts/scan_live_site.py
+++ b/scripts/scan_live_site.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Scan live mliezun.com pages for rendering/HTML issues."""
+
+from __future__ import annotations
+
+import glob
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections import defaultdict
+
+BASE = "https://mliezun.com"
+UA = {"User-Agent": "Mozilla/5.0 (compatible; mliezun-site-scan/1.0)"}
+
+
+def fetch(path: str) -> tuple[int, str]:
+    url = BASE + (path if path != "/" else "/")
+    req = urllib.request.Request(url, headers=UA)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.status, resp.read().decode("utf-8", errors="replace")
+
+
+def local_paths() -> list[str]:
+    paths = []
+    for file in glob.glob("docs/**/*.html", recursive=True):
+        rel = file.removeprefix("docs")
+        if rel == "/index.html":
+            paths.append("/")
+        else:
+            paths.append(rel)
+    return sorted(set(paths))
+
+
+def check_html(path: str, html: str) -> list[str]:
+    problems: list[str] = []
+
+    if path.endswith(".html") or path == "/":
+        if "Â·" in html:
+            problems.append("mojibake: Â· in page")
+        if re.search(r"class=\"archive-entry\"[\s\S]{0,800}ai-tag-read-more", html):
+            problems.append("invalid nested link in archive entry")
+        if "<main" not in html and "google" not in path:
+            problems.append("missing <main> landmark")
+        if "/assets/css/style.css" not in html and "google" not in path:
+            problems.append("missing site stylesheet")
+        if "masthead-brand" not in html and "google" not in path:
+            problems.append("missing masthead branding")
+
+    if path == "/":
+        entries = len(re.findall(r'class="archive-entry"', html))
+        if entries != 41:
+            problems.append(f"homepage has {entries} archive entries (expected 41)")
+        years = re.findall(r'id="year-(\d{4})"', html)
+        if years and years[0] != max(years):
+            problems.append(f"archive years start with {years[0]} (expected {max(years)} first)")
+
+    if re.match(r"/20\d\d/", path):
+        if "<article" not in html:
+            problems.append("article page missing <article>")
+        if "journal-meta-wrap" not in html and "article-byline" not in html:
+            problems.append("article missing byline/metadata")
+
+    assets = set(re.findall(r'(?:src|href)="(/assets/[^"]+)"', html))
+    for asset in assets:
+        try:
+            fetch(asset)
+        except urllib.error.HTTPError as exc:
+            problems.append(f"broken asset {asset} ({exc.code})")
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"broken asset {asset} ({exc})")
+
+    return problems
+
+
+def main() -> int:
+    issues: dict[str, list[str]] = defaultdict(list)
+    paths = [p for p in local_paths() if "google" not in p]
+
+    for path in paths:
+        try:
+            status, html = fetch(path)
+        except Exception as exc:  # noqa: BLE001
+            issues[path].append(f"fetch failed: {exc}")
+            continue
+        if status != 200:
+            issues[path].append(f"HTTP {status}")
+        issues[path].extend(check_html(path, html))
+
+    problems = {path: probs for path, probs in issues.items() if probs}
+    if not problems:
+        print(f"OK: scanned {len(paths)} pages, no issues found")
+        return 0
+
+    print(f"Issues on live site ({len(problems)} pages):\n")
+    for path, probs in sorted(problems.items()):
+        print(path)
+        for prob in probs:
+            print(f"  - {prob}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/pages/index.gr
+++ b/src/pages/index.gr
@@ -95,7 +95,7 @@ fn build_index(posts) {
     ] + featured + [
         [
             "div", ["class", "post-archive"],
-            u.foldr(u.map(years_list, fn (year) {
+            u.foldl(u.map(years_list, fn (year) {
                 return [
                     ["section", ["id", "year-" + year, "class", "archive-year-section"], [
                         ["div", ["class", "archive-year-header"], [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes rendering issues found while auditing the live site.

## Issues found on mliezun.com

1. **Partial mojibake (`Â·`)** on 3 article pages that contain emoji or em dashes — the previous whole-file encoding repair skipped them
2. **Homepage archive year order** — year sections rendered 2020→2026 instead of 2026→2020 due to `foldr` reversing the sorted year list

## Fixes

- Targeted mojibake replacements in `fix_html_encoding.py`
- `foldl` for year sections in `index.gr`
- Added `scripts/scan_live_site.py` for automated live checks

## Verified

- All 45 HTML pages generate without `Â·`
- Homepage years now `2026 … 2020`
- No broken assets, nested archive links, or console errors on sampled pages
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0935206-5d26-4ee4-a917-bf50241cc3fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0935206-5d26-4ee4-a917-bf50241cc3fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

