### PR TITLE
Remove logo from masthead hero

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -135,41 +135,19 @@ body {
     margin-bottom: var(--space-3);
 }
 
-.masthead-brand {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--space-2);
-    text-decoration: none;
-    color: inherit;
-}
-
-.masthead-logo {
-    display: block;
-    width: 2.75rem;
-    height: auto;
-    opacity: 0.92;
-    filter: invert(var(--invert-colors));
-    transition: opacity var(--transition-fast), transform var(--transition-fast);
-}
-
-.masthead-brand:hover .masthead-logo {
-    opacity: 1;
-    transform: translateY(-1px);
-}
-
 .masthead-title {
-    display: block;
+    display: inline-block;
     font-family: var(--font-serif);
     font-size: clamp(2rem, 5vw, 2.75rem);
     font-weight: 600;
     line-height: 1.12;
     letter-spacing: -0.025em;
     color: var(--text-primary);
+    text-decoration: none;
     transition: color var(--transition-fast);
 }
 
-.masthead-brand:hover .masthead-title {
+.masthead-title:hover {
     color: var(--accent);
 }
 

--- a/scripts/scan_live_site.py
+++ b/scripts/scan_live_site.py
@@ -44,8 +44,8 @@ def check_html(path: str, html: str) -> list[str]:
             problems.append("missing <main> landmark")
         if "/assets/css/style.css" not in html and "google" not in path:
             problems.append("missing site stylesheet")
-        if "masthead-brand" not in html and "google" not in path:
-            problems.append("missing masthead branding")
+        if "masthead-title" not in html and "google" not in path:
+            problems.append("missing masthead title")
 
     if path == "/":
         entries = len(re.findall(r'class="archive-entry"', html))

--- a/src/web.gr
+++ b/src/web.gr
@@ -159,10 +159,7 @@ class Web {
         return ["header", ["class", "journal-masthead"], [
             ["div", ["class", "masthead-inner"], [
                 ["div", ["class", "masthead-rule-top"], []],
-                ["a", ["href", "/", "class", "masthead-brand"], [
-                    ["img", ["src", "/assets/images/logo.png", "alt", "", "class", "masthead-logo", "width", "44", "height", "44"], []],
-                    ["span", ["class", "masthead-title"], "Miguel's dev blog"],
-                ]],
+                ["a", ["href", "/", "class", "masthead-title"], "Miguel's dev blog"],
                 ["p", ["class", "masthead-tagline"], "By Miguel Liezun · Programming & Side Projects"],
                 ["div", ["class", "masthead-rule"], []],
                 ["nav", ["class", "masthead-nav", "aria-label", "Site"], [


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the capital M image from the masthead hero. The site title remains a linked heading; favicon assets are unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0935206-5d26-4ee4-a917-bf50241cc3fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0935206-5d26-4ee4-a917-bf50241cc3fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

